### PR TITLE
event: add --around filter and fix sorting

### DIFF
--- a/pkg/cmd/events/io.go
+++ b/pkg/cmd/events/io.go
@@ -33,7 +33,7 @@ func PrintEvents(writer io.Writer, events []*corev1.Event) error {
 		message = strings.Replace(message, `"""`, `"`, -1)
 		message = strings.Replace(message, "\t", "\t", -1)
 
-		if _, err := fmt.Fprintf(writer, "%s (%d) %q %s %s\n", event.FirstTimestamp.Format("15:04:05"), event.Count, event.InvolvedObject.Namespace, event.Reason, message); err != nil {
+		if _, err := fmt.Fprintf(writer, "%s (%d) %q %s %s\n", event.LastTimestamp.Format("15:04:05"), event.Count, event.InvolvedObject.Namespace, event.Reason, message); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/events/sort.go
+++ b/pkg/cmd/events/sort.go
@@ -11,7 +11,7 @@ func (s byTime) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 func (s byTime) Less(i, j int) bool {
-	return s[i].FirstTimestamp.Before(&s[j].FirstTimestamp)
+	return s[i].LastTimestamp.Before(&s[j].LastTimestamp)
 }
 
 type byFrequency []*corev1.Event


### PR DESCRIPTION
This add `--around` and `--around-duration` flags to `event` command which will filter only events that have `LastTimestamp` around the time specified in `around` option. 
The second flag controls the duration +/- to display events around (10 minutes is default).

Eg.

```
$ oc dev-tool event -f event.json --around=21:11
```

This also fixes the sorting and time printing for events to use LastTimestamp, not the FirstTimestamp. For bug triage it is important to know when the event occurred the last time, not the first time and showing the first time might be misleading.