### PR TITLE
Initial version of event-filter tool based on jqgrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ cluster-debug-tools
 * `analyze-e2e`     inspects the artifacts gathered during e2e-aws run and analyze them.
 * `audit`           inspects the audit logs captured during CI test run.
 * `event`           inspects the event logs captured during CI test run.
+* `event-filter`    filters the event logs captured during CI test run on a webpage (based on jqgrid).
 * `inspect-certs`   inspects the certs, keys, and ca-bundles in a set of resources.
 * `revision-status` counts failed installer pods and current revision of static pods.
 

--- a/web/event-filter/event-filter-file-select.html
+++ b/web/event-filter/event-filter-file-select.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <!-- The link to the CSS that the grid needs -->
+      <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/themes/redmond/jquery-ui.min.css">
+      <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/free-jqgrid/4.15.5/css/ui.jqgrid.min.css">
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/free-jqgrid/4.15.5/jquery.jqgrid.min.js"></script>
+      <meta charset="utf-8" />
+      <title>Openshift Event Grid Viewer</title>
+   </head>
+   <body>
+      <style type="text/css">
+         /* set the size of the datepicker search control for Order Date*/
+         #ui-datepicker-div { font-size:11px; }
+         /* set the size of the autocomplete search control*/
+         .ui-menu-item {
+         }
+         .ui-autocomplete {
+         font-size: 11px;
+         }       
+         .myAltRowClass { background-color: #DDDDDC; background-image: none; }
+      </style>
+      <label for="input-file">Specify an events file:</label><br>
+      <input type="file" id="input-file">
+      <script type="text/javascript">
+      <script type="text/javascript"> 
+         document.getElementById('input-file')
+             .addEventListener('change', getFile)
+         
+         function getFile(event) {
+             const input = event.target
+             if ('files' in input && input.files.length > 0) {
+                 placeFileContent(
+                     document.getElementById('content-target'),
+                     input.files[0])
+             }
+         }
+         
+         var _theGrid;
+         
+         function placeFileContent(target, file) {
+             readFileContent(file).then(allEvents => {
+                 var filter;
+                 if (typeof _theGrid !== 'undefined') {
+                     $("#jqGrid").jqGrid('clearGridData');
+                     $("#jqGrid").jqGrid('setGridParam', {
+                         datatype: "jsonstring",
+                         datastr: allEvents
+                     });
+                     $("#jqGrid").trigger('reloadGrid');
+                 } else {
+                     _theGrid = $("#jqGrid").jqGrid({
+         
+                         datatype: "jsonstring",
+                         datastr: allEvents,
+                         altRows: true,
+                         altclass: 'myAltRowClass',
+                         jsonReader: {
+                             root: "items"
+                         },
+                         colModel: [{
+                                 label: "Type",
+                                 name: 'type',
+                                 key: false,
+                                 width: 60,
+                                 colmenu: true,
+                                 searchoptions: {
+                                     searchOperMenu: false,
+                                 }
+                             }, {
+                                 label: "Component",
+                                 //sorttype: 'integer',
+                                 name: 'source.component',
+                                 key: false,
+                                 width: 220,
+                                 colmenu: true,
+                                 searchoptions: {
+                                     searchOperMenu: false,
+                                     sopt: ['cn']
+                                 }
+                             },
+                             {
+                                 label: "Reason",
+                                 //sorttype: 'integer',
+                                 name: 'reason',
+                                 key: false,
+                                 width: 165,
+                                 colmenu: true,
+                                 searchoptions: {
+                                     searchOperMenu: false,
+                                     sopt: ['cn']
+                                 }
+                             },
+                             {
+                                 label: "Message",
+                                 name: 'message',
+                                 width: 635,
+                                 hidedlg: true,
+                                 // stype defines the search type control - in this case HTML select (dropdownlist)
+                                 // searchoptions value - name values pairs for the dropdown - they will appear as options
+                                 searchoptions: {
+                                     searchOperMenu: false,
+                                     sopt: ['cn']
+                                 }
+                             },
+                             {
+                                 label: "firstTimestamp",
+                                 name: 'firstTimestamp',
+                                 width: 150,
+                                 stype: 'text',
+                                 searchoptions: {
+                                     searchOperMenu: false,
+                                     sopt: ['eq', 'gt', 'lt', 'ge', 'le']
+                                 }
+                             }, {
+                                 label: "lastTimestamp",
+                                 name: 'lastTimestamp',
+                                 width: 150,
+                                 stype: 'text',
+                                 searchoptions: {
+                                     searchOperMenu: false,
+                                     sopt: ['eq', 'gt', 'lt', 'ge', 'le']
+                                 }
+                             },
+                             {
+                                 label: "involvedObject",
+                                 name: 'involvedObject.name',
+                                 width: 260,
+                                 searchoptions: {
+                                     // dataInit is the client-side event that fires upon initializing the toolbar search field for a column
+                                     // use it to place a third party control to customize the toolbar
+                                     searchOperMenu: false,
+                                     sopt: ['cn']
+                                 }
+                             },
+                             {
+                                 label: "Count",
+                                 sorttype: 'number',
+                                 name: 'count',
+                                 width: 100,
+                                 sopt: ['eq', 'gt', 'lt', 'ge', 'le']
+                             },
+                             {
+                                 label: "id",
+                                 name: 'metadata.uid',
+                                 key: true,
+                                 width: 220,
+                                 colmenu: true,
+                                 searchoptions: {
+                                     searchOperMenu: false,
+                                 }
+                             }
+                         ],
+                         //loadonce: true,
+                         viewrecords: true,
+                         width: 1780,
+                         height: 'auto',
+                         rowNum: 30,
+                         colMenu: true,
+                         shrinkToFit: false,
+                         pager: "#jqGridPager"
+                     });
+                     // activate the toolbar searching
+                     $('#jqGrid').jqGrid('filterToolbar', {
+                         // JSON stringify all data from search, including search toolbar operators
+                         stringResult: true,
+                         // instuct the grid toolbar to show the search options
+                         searchOperators: true
+                     });
+                     // activate the toolbar searching
+                     $('#jqGrid').jqGrid('navGrid', "#jqGridPager", {
+                         search: true, // show search button on the toolbar
+                         add: false,
+                         edit: false,
+                         del: false,
+                         refresh: true
+                     }, {}, {}, {}, {
+                         multipleSearch: true
+                         //stringResult : false
+                         //multipleGroup : true
+                     });
+                     var timer;
+                     $("#search_cells").on("keyup", function() {
+                         var self = this;
+                         if (timer) {
+                             clearTimeout(timer);
+                         }
+                         timer = setTimeout(function() {
+                             //timer = null;
+                             $("#jqGrid").jqGrid('filterInput', self.value);
+                         }, 0);
+                     });
+                 }
+             }).catch(error => console.log(error))
+         }
+         
+         function readFileContent(file) {
+             const reader = new FileReader()
+             return new Promise((resolve, reject) => {
+                 reader.onload = event => resolve(event.target.result)
+                 reader.onerror = error => reject(error)
+                 reader.readAsText(file)
+             })
+         } 
+      </script>
+      <hr />
+      <div style="padding-bottom: 10px;">
+         <label for="search_cells">
+         Search in anyfield: 
+         </label>
+         <input id="search_cells" type="search"/>
+      </div>
+      <table id="jqGrid"></table>
+      <div id="jqGridPager"></div>
+   </body>

--- a/web/event-filter/event-filter-local-ajax.html
+++ b/web/event-filter/event-filter-local-ajax.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <!-- The link to the CSS that the grid needs -->
+      <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/themes/redmond/jquery-ui.min.css">
+      <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/free-jqgrid/4.15.5/css/ui.jqgrid.min.css">
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/free-jqgrid/4.15.5/jquery.jqgrid.min.js"></script>
+      <meta charset="utf-8" />
+      <title>Openshift Event Grid Viewer</title>
+   </head>
+   <body>
+      <style type="text/css">
+         /* set the size of the datepicker search control for Order Date*/
+         #ui-datepicker-div { font-size:11px; }
+         /* set the size of the autocomplete search control*/
+         .ui-menu-item {
+         }
+         .ui-autocomplete {
+         font-size: 11px;
+         }       
+         .myAltRowClass { background-color: #DDDDDC; background-image: none; }
+      </style>
+      <table id="jqGrid"></table>
+      <div id="jqGridPager"></div>
+      <script type="text/javascript"> 
+         var _theGrid;
+         $(document).ready(function () {
+         var filter;
+         _theGrid = $("#jqGrid").jqGrid({
+             url: 'events.json',
+             mtype: "GET",
+             datatype: "json",
+             altRows: true,
+             altclass: "myAltRowClass",
+             jsonReader: {
+                 root: "items"
+             },
+             colModel: [{
+                     label: "Type",
+                     name: "type",
+                     key: false,
+                     width: 60,
+                     colmenu: true,
+                     searchoptions: {
+                         searchOperMenu: false,
+                     }
+                 }, {
+                     label: "Component",
+                     //sorttype: "integer",
+                     name: "source.component",
+                     key: false,
+                     width: 220,
+                     colmenu: true,
+                     searchoptions: {
+                         searchOperMenu: false,
+                         sopt: ["cn"]
+                     }
+                 },
+                 {
+                     label: "Reason",
+                     //sorttype: "integer",
+                     name: "reason",
+                     key: false,
+                     width: 165,
+                     colmenu: true,
+                     searchoptions: {
+                         searchOperMenu: false,
+                         sopt: ["cn"]
+                     }
+                 },
+                 {
+                     label: "Message",
+                     name: "message",
+                     width: 635,
+                     hidedlg: true,
+                     // stype defines the search type control - in this case HTML select (dropdownlist)
+                     // searchoptions value - name values pairs for the dropdown - they will appear as options
+                     searchoptions: {
+                         searchOperMenu: false,
+                         sopt: ["cn"]
+                     }
+                 },
+                 {
+                     label: "firstTimestamp",
+                     name: "firstTimestamp",
+                     width: 150,
+                     stype: "text",
+                     searchoptions: {
+                         searchOperMenu: false,
+                         sopt: ["eq", "gt", "lt", "ge", "le"]
+                     }
+                 }, {
+                     label: "lastTimestamp",
+                     name: "lastTimestamp",
+                     width: 150,
+                     stype: "text",
+                     searchoptions: {
+                         searchOperMenu: false,
+                         sopt: ["eq", "gt", "lt", "ge", "le"]
+                     }
+                 },
+                 {
+                     label: "involvedObject",
+                     name: "involvedObject.name",
+                     width: 260,
+                     searchoptions: {
+                         // dataInit is the client-side event that fires upon initializing the toolbar search field for a column
+                         // use it to place a third party control to customize the toolbar
+                         searchOperMenu: false,
+                         sopt: ["cn"]
+                     }
+                 },
+                 {
+                     label: "Count",
+                     sorttype: "number",
+                     name: "count",
+                     width: 100,
+                     sopt: ["eq", "gt", "lt", "ge", "le"]
+                 },
+                 {
+                     label: "id",
+                     name: "metadata.uid",
+                     key: true,
+                     width: 220,
+                     colmenu: true,
+                     searchoptions: {
+                         searchOperMenu: false,
+                     }
+                 }
+             ],
+             //loadonce: true,
+             viewrecords: true,
+             width: 1780,
+             height: "auto",
+             rowNum: 100,
+             colMenu: true,
+             shrinkToFit: false,
+             pager: "#jqGridPager"
+         });
+         // activate the toolbar searching
+         $("#jqGrid").jqGrid("filterToolbar", {
+             // JSON stringify all data from search, including search toolbar operators
+             stringResult: true,
+             // instuct the grid toolbar to show the search options
+             searchOperators: true
+         });
+         // activate the toolbar searching
+         $("#jqGrid").jqGrid("navGrid", "#jqGridPager", {
+             search: true, // show search button on the toolbar
+             add: false,
+             edit: false,
+             del: false,
+             refresh: true
+         }, {}, {}, {}, {
+             multipleSearch: true
+             //stringResult : false
+             //multipleGroup : true
+         });
+         });
+      </script>
+   </body>
+</html>

--- a/web/event-filter/event-filter-local-jsonstr.html
+++ b/web/event-filter/event-filter-local-jsonstr.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <!-- The link to the CSS that the grid needs -->
+      <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/themes/redmond/jquery-ui.min.css">
+      <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/free-jqgrid/4.15.5/css/ui.jqgrid.min.css">
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/free-jqgrid/4.15.5/jquery.jqgrid.min.js"></script>
+      <meta charset="utf-8" />
+      <title>Openshift Event Grid Viewer</title>
+   </head>
+   <body>
+      <script type="text/javascript" src="all-events.json.js"></script>
+      <style type="text/css">
+         /* set the size of the datepicker search control for Order Date*/
+         #ui-datepicker-div { font-size:11px; }
+         /* set the size of the autocomplete search control*/
+         .ui-menu-item {
+         }
+         .ui-autocomplete {
+         font-size: 11px;
+         }       
+         .myAltRowClass { background-color: #DDDDDC; background-image: none; }
+      </style>
+      <table id="jqGrid"></table>
+      <div id="jqGridPager"></div>
+      <script type="text/javascript"> 
+         var _theGrid;
+         $(document).ready(function () {
+         var filter;
+         _theGrid = $("#jqGrid").jqGrid({
+         datatype: "jsonstring",
+         datastr: allEvents,
+             altRows: true,
+             altclass: "myAltRowClass",
+             jsonReader: {
+                 root: "items"
+             },
+             colModel: [{
+                     label: "Type",
+                     name: "type",
+                     key: false,
+                     width: 60,
+                     colmenu: true,
+                     searchoptions: {
+                         searchOperMenu: false,
+                     }
+                 }, {
+                     label: "Component",
+                     //sorttype: "integer",
+                     name: "source.component",
+                     key: false,
+                     width: 220,
+                     colmenu: true,
+                     searchoptions: {
+                         searchOperMenu: false,
+                         sopt: ["cn"]
+                     }
+                 },
+                 {
+                     label: "Reason",
+                     //sorttype: "integer",
+                     name: "reason",
+                     key: false,
+                     width: 165,
+                     colmenu: true,
+                     searchoptions: {
+                         searchOperMenu: false,
+                         sopt: ["cn"]
+                     }
+                 },
+                 {
+                     label: "Message",
+                     name: "message",
+                     width: 635,
+                     hidedlg: true,
+                     // stype defines the search type control - in this case HTML select (dropdownlist)
+                     // searchoptions value - name values pairs for the dropdown - they will appear as options
+                     searchoptions: {
+                         searchOperMenu: false,
+                         sopt: ["cn"]
+                     }
+                 },
+                 {
+                     label: "firstTimestamp",
+                     name: "firstTimestamp",
+                     width: 150,
+                     stype: "text",
+                     searchoptions: {
+                         searchOperMenu: false,
+                         sopt: ["eq", "gt", "lt", "ge", "le"]
+                     }
+                 }, {
+                     label: "lastTimestamp",
+                     name: "lastTimestamp",
+                     width: 150,
+                     stype: "text",
+                     searchoptions: {
+                         searchOperMenu: false,
+                         sopt: ["eq", "gt", "lt", "ge", "le"]
+                     }
+                 },
+                 {
+                     label: "involvedObject",
+                     name: "involvedObject.name",
+                     width: 260,
+                     searchoptions: {
+                         // dataInit is the client-side event that fires upon initializing the toolbar search field for a column
+                         // use it to place a third party control to customize the toolbar
+                         searchOperMenu: false,
+                         sopt: ["cn"]
+                     }
+                 },
+                 {
+                     label: "Count",
+                     sorttype: "number",
+                     name: "count",
+                     width: 100,
+                     sopt: ["eq", "gt", "lt", "ge", "le"]
+                 },
+                 {
+                     label: "id",
+                     name: "metadata.uid",
+                     key: true,
+                     width: 220,
+                     colmenu: true,
+                     searchoptions: {
+                         searchOperMenu: false,
+                     }
+                 }
+             ],
+             //loadonce: true,
+             viewrecords: true,
+             width: 1780,
+             height: "auto",
+             rowNum: 100,
+             colMenu: true,
+             shrinkToFit: false,
+             pager: "#jqGridPager"
+         });
+         // activate the toolbar searching
+         $("#jqGrid").jqGrid("filterToolbar", {
+             // JSON stringify all data from search, including search toolbar operators
+             stringResult: true,
+             // instuct the grid toolbar to show the search options
+             searchOperators: true
+         });
+         // activate the toolbar searching
+         $("#jqGrid").jqGrid("navGrid", "#jqGridPager", {
+             search: true, // show search button on the toolbar
+             add: false,
+             edit: false,
+             del: false,
+             refresh: true
+         }, {}, {}, {}, {
+             multipleSearch: true
+             //stringResult : false
+             //multipleGroup : true
+         });
+         });
+      </script>
+   </body>
+</html>


### PR DESCRIPTION
The jqgrid plugin is customized to filter OpenShift events generated during CI run and must-gather:

The following three different versions are provided in the web/event-filter/ directory:
1. event-filter-file-select.html
    Allows user to select a local file on the disk.
2. web/event-filter/event-filter-local-jsonstr.html
    Reads all-events.json.js file generated using must-gather. 
3. web/event-filter/event-filter-local-ajax.html
    Reads events.json in the current directory

