### PR TITLE
filter by audit event stage

### DIFF
--- a/pkg/cmd/audit/audit_filter.go
+++ b/pkg/cmd/audit/audit_filter.go
@@ -328,6 +328,29 @@ func URIToParts(uri string) (string, schema.GroupVersionResource, string, string
 	return ns, gvr, name, ""
 }
 
+type FilterByStage struct {
+	Stages sets.String
+}
+
+func (f *FilterByStage) FilterEvents(events ...*auditv1.Event) []*auditv1.Event {
+	// in case we end up calling the filter with an empty set of stage then we have nothing to filter.
+	if len(f.Stages) == 0 {
+		return events
+	}
+
+	ret := []*auditv1.Event{}
+	for i := range events {
+		event := events[i]
+
+		// TODO: an event not having a stage, what do we do?
+		if f.Stages.Has(string(event.Stage)) {
+			ret = append(ret, event)
+		}
+	}
+
+	return ret
+}
+
 type FilterByAfter struct {
 	After time.Time
 }


### PR DESCRIPTION
A request is captured twice in the apiserver audit log. It is known as stage, the first entry is `RequestReceived`, it is
added as soon as the request is received and does not have any response status. The second entry is `ResponseComplete` and it is written as soon as the request is completed with a response.

The stage filter adds ability to filter by these stages. We need to be able to filter by stages since for some operations we don't want to include both entries in computation. The default behavior is to include all stages which maintains backward compatibility.

Below is a demonstration of how the stage filtering works. we want to look at the top for `verb=get`. The first command does not apply the stage filter and so we see double the number of requests. Once you apply the stage filter `--stage=ResponseComplete` the result comes down to exactly half.
```
 $ kubectl-dev_tool audit -f audit.3.log --verb=get --output=top --by=verb

Top 5 "GET":
  14432x [          0s] [  0] /healthz                                                                  [system:anonymous]
   4962x [          0s] [  0] /api/v1/namespaces/kube-system/configmaps/kube-scheduler                  [system:openshift-master]
   3344x [          0s] [  0] /api/v1/namespaces/kube-system/configmaps/openshift-master-controllers    [system:openshift-master]
   3300x [          0s] [  0] /api/v1/namespaces/kube-system/configmaps/kube-controller-manager         [system:openshift-master]
   3222x [          0s] [  0] /api/v1/namespaces/openshift-monitoring/secrets/node-exporter-token-7vk9h [system:openshift-master]


dhl_incident_20200703_01/audit_logs $ kubectl-dev_tool audit -f audit.3.log --verb=get --stage=RequestReceived --output=top --by=verb

Top 5 "GET":
   7216x [          0s] [  0] /healthz                                                                  [system:anonymous]
   2481x [          0s] [  0] /api/v1/namespaces/kube-system/configmaps/kube-scheduler                  [system:openshift-master]
   1672x [          0s] [  0] /api/v1/namespaces/kube-system/configmaps/openshift-master-controllers    [system:openshift-master]
   1650x [          0s] [  0] /api/v1/namespaces/kube-system/configmaps/kube-controller-manager         [system:openshift-master]
   1611x [          0s] [  0] /api/v1/namespaces/openshift-monitoring/secrets/node-exporter-token-7vk9h [system:openshift-master]


dhl_incident_20200703_01/audit_logs $ kubectl-dev_tool audit -f audit.3.log --verb=get --stage=ResponseComplete --output=top --by=verb

Top 5 "GET":
   7216x [     3.203ms] [200] /healthz                                                                  [system:anonymous]
   2481x [     5.634ms] [200] /api/v1/namespaces/kube-system/configmaps/kube-scheduler                  [system:openshift-master]
   1672x [     9.038ms] [200] /api/v1/namespaces/kube-system/configmaps/openshift-master-controllers    [system:openshift-master]
   1650x [     3.431ms] [200] /api/v1/namespaces/kube-system/configmaps/kube-controller-manager         [system:openshift-master]
   1611x [      4.55ms] [200] /api/v1/namespaces/openshift-monitoring/secrets/node-exporter-token-7vk9h [system:openshift-master]

```

