### PR TITLE
print summary of events for top

### DIFF
--- a/pkg/cmd/audit/audit.go
+++ b/pkg/cmd/audit/audit.go
@@ -178,11 +178,11 @@ func (o *AuditOptions) Run() error {
 		return err
 	}
 	events = filters.FilterEvents(events...)
-
 	switch o.output {
 	case "":
 		PrintAuditEvents(o.Out, events)
 	case "top":
+		PrintSummary(o.Out, events)
 		switch o.topBy {
 		case "verb":
 			PrintTopByVerbAuditEvents(o.Out, events)

--- a/pkg/cmd/audit/io.go
+++ b/pkg/cmd/audit/io.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
@@ -390,4 +391,17 @@ func PrintTopByNamespace(writer io.Writer, events []*auditv1.Event) {
 	for _, r := range result {
 		fmt.Fprintf(w, "%dx\t %s\n", r.count, r.name)
 	}
+}
+
+func PrintSummary(w io.Writer, events []*auditv1.Event) {
+	if len(events) == 0 {
+		return
+	}
+
+	first := events[0]
+	last := events[len(events)-1]
+	duration := last.RequestReceivedTimestamp.Time.Sub(first.RequestReceivedTimestamp.Time)
+
+	fmt.Fprintf(w, "count: %d, first: %s, last: %s, duration: %s\n", len(events),
+		first.RequestReceivedTimestamp.Time.Format(time.RFC3339), last.RequestReceivedTimestamp.Time.Format(time.RFC3339), duration.String())
 }


### PR DESCRIPTION
An example:
```
$ kubectl-dev_tool audit -f logs_from_masters  --output=top --by=httpstatus

count: 2517228, first: 2020-07-30T16:10:00-04:00, last: 2020-07-30T16:51:10-04:00, duration: 41m10.577273s

Top 5 101 (of 1292 total hits):
.
.
.
```