### PR TITLE
top by namespace

### DIFF
--- a/pkg/cmd/audit/audit.go
+++ b/pkg/cmd/audit/audit.go
@@ -101,7 +101,7 @@ func NewCmdAudit(parentName string, streams genericclioptions.IOStreams) *cobra.
 	cmd.Flags().StringSliceVarP(&o.namespaces, "namespace", "n", o.namespaces, "Filter result of search to only contain the specified namespace.)")
 	cmd.Flags().StringSliceVar(&o.names, "name", o.names, "Filter result of search to only contain the specified name.)")
 	cmd.Flags().StringSliceVar(&o.users, "user", o.users, "Filter result of search to only contain the specified user.)")
-	cmd.Flags().StringVar(&o.topBy, "by", o.topBy, "Switch the top output format (eg. -o top -by [verb,user,resource]).")
+	cmd.Flags().StringVar(&o.topBy, "by", o.topBy, "Switch the top output format (eg. -o top -by [verb,user,resource,httpstatus,namespace]).")
 	cmd.Flags().BoolVar(&o.failedOnly, "failed-only", false, "Filter result of search to only contain http failures.)")
 	cmd.Flags().StringVar(&o.beforeString, "before", o.beforeString, "Filter result of search to only before a timestamp.)")
 	cmd.Flags().StringVar(&o.afterString, "after", o.afterString, "Filter result of search to only after a timestamp.)")
@@ -192,6 +192,8 @@ func (o *AuditOptions) Run() error {
 			PrintTopByResourceAuditEvents(o.Out, events)
 		case "httpstatus":
 			PrintTopByHTTPStatusCodeAuditEvents(o.Out, events)
+		case "namespace":
+			PrintTopByNamespace(o.Out, events)
 		default:
 			return fmt.Errorf("unsupported -by value")
 		}


### PR DESCRIPTION
Not sure if there is a way to achieve this with the existing options.

Example:
```
$ kubectl-dev_tool audit -f logs_from_masters--resource=secrets.* --user=system:openshift-master --output=top --by=namespace

33004x               openshift-monitoring
22936x               pnp-sdc-uat
14348x               cloudmgmt
11372x               openshift-node
9264x                its-machine-learning-platform-test
8544x                collectorforopenshift
7636x                openshift-infra
7312x                openshift-metrics-server
5760x                openshift-sdn
5632x                logging
4488x                kube-system
2752x                pep-flow-address-service-build
2456x                gbs-fmm-prod
2244x                management-infra
2164x                gbs-fmm-int
1756x                pnp-sdc-prod
1596x                default
1336x                gbs-fmm-test
976x                 amq-admin
968x                 its-virtual-assistant-dmz-prod
```