### PR TITLE
fix resource filter for request URI with query parameters

### DIFF
--- a/pkg/cmd/audit/audit_filter.go
+++ b/pkg/cmd/audit/audit_filter.go
@@ -231,6 +231,10 @@ func URIToParts(uri string) (string, schema.GroupVersionResource, string, string
 			uri = uri[1:]
 		}
 	}
+
+	// some request URL has query parameters like: /apis/image.openshift.io/v1/images?limit=500&resourceVersion=0
+	// we are not interested in the query parameters.
+	uri = strings.Split(uri, "?")[0]
 	parts := strings.Split(uri, "/")
 	if len(parts) == 0 {
 		return ns, gvr, name, ""


### PR DESCRIPTION
resource filter should not fail when the request URI has query parameters. For a request that has query parameters like below:
	`/apis/image.openshift.io/v1/images?limit=500&resourceVersion=0`
"images" resource filtering does not match since the query parameters causes the resource to be set to `images?limit=500&resourceVersion=0`. This causes a mismatch.

Drop the query parameters from the request URI.

How to reproduce:
Make sure you have an audit log with Request URIs with query parameters like - `/apis/image.openshift.io/v1/images?limit=500&resourceVersion=0`

Use `jq` to directly query an audit log:
```
$ cat audit.log | jq '. | select(.verb=="list" and .objectRef.resource == "images" and 
.stage == "ResponseComplete") | .stageTimestamp + " -> " + .user.username + " -> "  + .requestURI' | wc -l

294
```

Without the fix, the tool does not return any record for the LIST images call. With the fix, we can see the the LIST calls.
```
$ kubectl-dev_tool audit -f audit.log --stage=ResponseComplete  --verb=list --resource=images.* 
--output=top --by=user

count: 294, first: 2020-08-31T09:15:56-04:00, last: 2020-08-31T09:23:07-04:00, duration: 7m10.148927s
147x                 system:apiserver
147x                 system:openshift-master
```
