### PR TITLE
update audit command to avoid counting unique timeout and resourceVersion as unique requests for summarizing counts

### DIFF
--- a/pkg/cmd/audit/io.go
+++ b/pkg/cmd/audit/io.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -203,7 +205,7 @@ func PrintTopByVerbAuditEvents(writer io.Writer, events []*auditv1.Event) {
 		for _, event := range eventList {
 			found := false
 			for i, countedEvent := range countedEvents {
-				if countedEvent.event.RequestURI == event.RequestURI && countedEvent.event.User.Username == event.User.Username {
+				if IsEquivalentAuditURI(countedEvent.event.RequestURI, event.RequestURI) && countedEvent.event.User.Username == event.User.Username {
 					countedEvents[i].count += 1
 					found = true
 					break
@@ -328,7 +330,7 @@ func PrintTopByHTTPStatusCodeAuditEvents(writer io.Writer, events []*auditv1.Eve
 		for _, event := range eventList {
 			found := false
 			for i, countedEvent := range countedEvents {
-				if countedEvent.event.RequestURI == event.RequestURI && countedEvent.event.User.Username == event.User.Username {
+				if IsEquivalentAuditURI(countedEvent.event.RequestURI, event.RequestURI) && countedEvent.event.User.Username == event.User.Username {
 					countedEvents[i].count += 1
 					found = true
 					break
@@ -404,4 +406,43 @@ func PrintSummary(w io.Writer, events []*auditv1.Event) {
 
 	fmt.Fprintf(w, "count: %d, first: %s, last: %s, duration: %s\n", len(events),
 		first.RequestReceivedTimestamp.Time.Format(time.RFC3339), last.RequestReceivedTimestamp.Time.Format(time.RFC3339), duration.String())
+}
+
+// IsEquivalentAuditURI is fuzzy matcher that allows equivalence on non-exact matches.  This is important for watches and
+// for lists since they can pass a resourceversion and timeout which always diffs, but is rarely importantly different
+func IsEquivalentAuditURI(lhs, rhs string) bool {
+	if lhs == rhs {
+		return true
+	}
+	lhsURL, err := url.Parse("https://example.com" + lhs)
+	if err != nil {
+		panic(err)
+	}
+	rhsURL, err := url.Parse("https://example.com" + rhs)
+	if err != nil {
+		panic(err)
+	}
+	if lhsURL.Path != rhsURL.Path {
+		return false
+	}
+	lhsQueries := lhsURL.Query()
+	rhsQueries := lhsURL.Query()
+
+	lhsKeys := sets.StringKeySet(lhsQueries)
+	rhsKeys := sets.StringKeySet(rhsQueries)
+	lhsKeys.Delete("timeout", "timeoutSeconds", "resourceVersion", "continue")
+	rhsKeys.Delete("timeout", "timeoutSeconds", "resourceVersion", "continue")
+	if !lhsKeys.Equal(rhsKeys) {
+		return false
+	}
+
+	for _, queryName := range lhsKeys.List() {
+		lhsQueryValue := lhsQueries[queryName]
+		rhsQueryValue := rhsQueries[queryName]
+		if !reflect.DeepEqual(lhsQueryValue, rhsQueryValue) {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
resourceVersion and timeout are different for every watch, so we don't see the total of watches sent by a single component

Fixing this shows the data more clearly.

```
Top 5 "WATCH" (of 4103 total hits):
   3786x [       770µs] [200] /api/v1/namespaces/kube-system/configmaps?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dextension-apiserver-authentication&resourceVersion=13897&timeout=5m40s&timeoutSeconds=340&watch=true [system:serviceaccount:openshift-apiserver:openshift-apiserver-sa]
     23x [    15.838ms] [200] /apis/operator.openshift.io/v1alpha1/imagecontentsourcepolicies?allowWatchBookmarks=true&resourceVersion=9121&timeout=6m33s&timeoutSeconds=393&watch=true                                             [system:serviceaccount:openshift-apiserver:openshift-apiserver-sa]
     22x [    28.521ms] [200] /api/v1/limitranges?allowWatchBookmarks=true&resourceVersion=9121&timeout=5m40s&timeoutSeconds=340&watch=true                                                                                         [system:serviceaccount:openshift-apiserver:openshift-apiserver-sa]
     22x [     1.903ms] [200] /api/v1/resourcequotas?allowWatchBookmarks=true&resourceVersion=9121&timeout=6m15s&timeoutSeconds=375&watch=true                                                                                      [system:serviceaccount:openshift-apiserver:openshift-apiserver-sa]
     21x [    28.956ms] [200] /apis/quota.openshift.io/v1/clusterresourcequotas?allowWatchBookmarks=true&resourceVersion=9121&timeout=5m43s&timeoutSeconds=343&watch=true                                                           [system:serviceaccount:openshift-apiserver:openshift-apiserver-sa]

```