### PR TITLE
Do not apply local timezone when formatting received timestamps

### DIFF
--- a/pkg/cmd/audit/io.go
+++ b/pkg/cmd/audit/io.go
@@ -42,7 +42,7 @@ func PrintAuditEvents(writer io.Writer, events []*auditv1.Event) {
 			code = event.ResponseStatus.Code
 		}
 		if _, err := fmt.Fprintf(w, "%s [%6s][%12s] [%3d]\t %s\t [%s]\n",
-			event.RequestReceivedTimestamp.Format("15:04:05"),
+			event.RequestReceivedTimestamp.UTC().Format("15:04:05"),
 			strings.ToUpper(event.Verb),
 			duration,
 			code,
@@ -86,7 +86,7 @@ func PrintAuditEventsWide(writer io.Writer, events []*auditv1.Event) {
 			code = event.ResponseStatus.Code
 		}
 		if _, err := fmt.Fprintf(w, "%s (%v) [%s][%s] [%d]\t %s\t [%s]\n",
-			event.RequestReceivedTimestamp.Format("15:04:05"),
+			event.RequestReceivedTimestamp.UTC().Format("15:04:05"),
 			event.AuditID,
 			strings.ToUpper(event.Verb),
 			duration,


### PR DESCRIPTION
Forcing the UTC format for printing the timestamps to make easier analyzing the output, especially when cross-referencing with the original audit logs (otherwise the local timezone will be applied)