### PR TITLE
adds request duration filter to the audit subcommand

### DIFF
--- a/pkg/cmd/audit/audit_filter.go
+++ b/pkg/cmd/audit/audit_filter.go
@@ -406,3 +406,19 @@ func (f *FilterByBefore) FilterEvents(events ...*auditv1.Event) []*auditv1.Event
 
 	return ret
 }
+
+type FilterByDuration struct {
+	Duration time.Duration
+}
+
+func (f *FilterByDuration) FilterEvents(events ...*auditv1.Event) []*auditv1.Event {
+	ret := []*auditv1.Event{}
+	for i := range events {
+		event := events[i]
+		if event.StageTimestamp.Sub(event.RequestReceivedTimestamp.Time) <= f.Duration {
+			ret = append(ret, event)
+		}
+	}
+
+	return ret
+}


### PR DESCRIPTION
The new filter is available under `--duration` flag and allows for filtering requests that didn't take longer than the specified time to complete.

For example the following command:

```
./kubectl-dev_tool audit -f /path/to/audit_logs -otop=50 --verb=watch --by=user --duration=30s --stage=ResponseComplete --http-status-code=200
```

could be used to find  `WATCH` requests that took less than 30 seconds (inclusive) to complete.