### PR TITLE
feat: audit multiple local files based off regex

### DIFF
--- a/pkg/cmd/audit/audit.go
+++ b/pkg/cmd/audit/audit.go
@@ -136,7 +136,7 @@ func (o *AuditOptions) Validate() error {
 			return err
 		}
 		if err := validateTopBy(o.topBy); err != nil {
-			return nil
+			return err
 		}
 	case o.output == "wide":
 	case o.output == "json":

--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+type FilterFunc func(s string) bool
+
+// RegexFilter filter based off of regex.MatchString
+func RegexFilter(re *regexp.Regexp) FilterFunc {
+	return func(s string) bool {
+		return re.MatchString(s)
+	}
+}
+
+// ListFilesInDir will filter list of files based on full path of the files
+// Ex. path /a/b/c/d.txt will be sent to filter function to be used
+func ListFilesInDir(dir string, match FilterFunc) ([]string, error) {
+	fileList := []string{}
+	walk := func(p string, f os.FileInfo, err error) error {
+		if f.IsDir() {
+			return nil
+		}
+		if match(p) {
+			fileList = append(fileList, p)
+		}
+		return nil
+	}
+	if _, err := os.Stat(dir); err != nil {
+		return nil, err
+	}
+	return fileList, filepath.Walk(dir, walk)
+}


### PR DESCRIPTION
With this feature you should be able to point at a local directory of an un-tar audit directory and with a matching regex to scoop up and check against many files with out needing to dig into the specific file names or if no regex is provided it will default to any audit log file in that directory.

Example use

```
kubectl-dev_tool audit --artifact-dir "my_artifacts" --artifact-regex="kube-apiserver\/.*audit.*.log(.gz)?" --verb update
--failed-only --namespace openshift-monitoring
```

