### PR TITLE
WIP: top by etcdlatency tracker

### DIFF
--- a/pkg/cmd/audit/audit.go
+++ b/pkg/cmd/audit/audit.go
@@ -105,7 +105,7 @@ func NewCmdAudit(parentName string, streams genericclioptions.IOStreams) *cobra.
 	cmd.Flags().StringSliceVarP(&o.namespaces, "namespace", "n", o.namespaces, "Filter result of search to only contain the specified namespace.")
 	cmd.Flags().StringSliceVar(&o.names, "name", o.names, "Filter result of search to only contain the specified name.)")
 	cmd.Flags().StringSliceVar(&o.users, "user", o.users, "Filter result of search to only contain the specified user.)")
-	cmd.Flags().StringVar(&o.topBy, "by", o.topBy, "Switch the top output format (eg. -o top -by [verb,user,resource,httpstatus,namespace]).")
+	cmd.Flags().StringVar(&o.topBy, "by", o.topBy, "Switch the top output format (eg. -o top -by [verb,user,resource,httpstatus,namespace,etcdlatency]).")
 	cmd.Flags().BoolVar(&o.failedOnly, "failed-only", false, "Filter result of search to only contain http failures.)")
 	cmd.Flags().Int32SliceVar(&o.httpStatusCodes, "http-status-code", o.httpStatusCodes, "Filter result of search to only certain http status codes (200,429).")
 	cmd.Flags().StringVar(&o.beforeString, "before", o.beforeString, "Filter result of search to only before a timestamp.)")
@@ -157,6 +157,7 @@ func validateTopBy(topBy string) error {
 	case "resource":
 	case "httpstatus":
 	case "namespace":
+	case "etcdlatency":
 	default:
 		return fmt.Errorf("unsupported -by value: [verb,user,resource,httpstatus,namespace]")
 	}
@@ -284,6 +285,8 @@ func (o *AuditOptions) Run() error {
 			PrintTopByHTTPStatusCodeAuditEvents(o.Out, numToDisplay, events)
 		case "namespace":
 			PrintTopByNamespace(o.Out, numToDisplay, events)
+		case "etcdlatency":
+			PrintTopByEtcdLatency(o.Out, numToDisplay, events)
 		default:
 			return fmt.Errorf("unsupported -by value")
 		}


### PR DESCRIPTION
I need to rethink the final format. Maybe we could examine all latency trackers and display the one with the highest latency.

I think I would like to turn this PR more into (probably different command than `top`):

```
Summary of the latencies (analysed requests: 100):
=================================================
ETCD                  : max=60.005694507s min=14.995694507s median=18.000694507s 90th=19.000694507s
Response Write        : max=451ns min=341ns median=396ns 90th=440ns
Serialize Response    : max=3.495429ms min=2.495429ms median=2.995429ms 90th=3.400429ms
Total Request Latency : max=61.00087027s min=15.00087027s median=19.00087027s 90th=20.00087027s
```


At the moment, the new command: 
 examines all events with etcdlatency >= time.Millisecond, 
 rounds the duration for easier aggregation (to the nearest value greater than or equal to the actual duration), 
 and counts the entries with the same latency.
 
```
kubectl-dev_tool audit -f audit.log --stage=ResponseComplete -o top=20 --by etcdlatency --before 2024-07-23T01:30:34+02:00

count: 37392, first: 2024-07-23T01:21:34+02:00, last: 2024-07-23T01:30:33+02:00, duration: 8m59.323233s
1611x                "apiserver.latency.k8s.io/etcd"=15s
654x                 "apiserver.latency.k8s.io/etcd"=16s
163x                 "apiserver.latency.k8s.io/etcd"=1m1s
156x                 "apiserver.latency.k8s.io/etcd"=1m0s
37x                  "apiserver.latency.k8s.io/etcd"=10s
27x                  "apiserver.latency.k8s.io/etcd"=2s
25x                  "apiserver.latency.k8s.io/etcd"=31s
18x                  "apiserver.latency.k8s.io/etcd"=30s
16x                  "apiserver.latency.k8s.io/etcd"=7s
15x                  "apiserver.latency.k8s.io/etcd"=22s
11x                  "apiserver.latency.k8s.io/etcd"=11s
8x                   "apiserver.latency.k8s.io/etcd"=35s
5x                   "apiserver.latency.k8s.io/etcd"=6s
4x                   "apiserver.latency.k8s.io/etcd"=21s
4x                   "apiserver.latency.k8s.io/etcd"=54s
3x                   "apiserver.latency.k8s.io/etcd"=527ms
3x                   "apiserver.latency.k8s.io/etcd"=37ms
3x                   "apiserver.latency.k8s.io/etcd"=39ms
3x                   "apiserver.latency.k8s.io/etcd"=536ms
2x                   "apiserver.latency.k8s.io/etcd"=16ms
```
