### PR TITLE
cmd/audit: introduce new stats option

### DIFF
--- a/pkg/cmd/audit/audit.go
+++ b/pkg/cmd/audit/audit.go
@@ -137,6 +137,7 @@ func (o *AuditOptions) Validate() error {
 		}
 	case o.output == "wide":
 	case o.output == "json":
+	case o.output == "stats":
 	default:
 		return fmt.Errorf("unsupported output format: top=N, wide, json")
 	}
@@ -296,6 +297,8 @@ func (o *AuditOptions) Run() error {
 				return err
 			}
 		}
+	case o.output == "stats":
+		PrintLatencyTrackersStatsAuditEvents(o.Out, events)
 	default:
 		return fmt.Errorf("unsupported output format")
 	}

--- a/pkg/cmd/audit/io.go
+++ b/pkg/cmd/audit/io.go
@@ -301,11 +301,16 @@ func PrintLatencyTrackersStatsAuditEvents(writer io.Writer, events []*auditv1.Ev
 		}
 	}
 
-	//TODO: sort trackers
+	sortedLatencyTrackers := []string{}
+	for latencyTracker, _ := range latencyTrackers {
+		sortedLatencyTrackers = append(sortedLatencyTrackers, latencyTracker)
+	}
+	sort.Strings(sortedLatencyTrackers)
 
 	w := tabwriter.NewWriter(writer, 0, 0, 2, ' ', tabwriter.AlignRight)
 	fmt.Fprintln(w, "======================================================================")
-	for latencyTracker, latencySummary := range latencySummaries {
+	for _, latencyTracker := range sortedLatencyTrackers {
+		latencySummary := latencySummaries[latencyTracker]
 		fmt.Fprintf(w, "%-50s: max=%v min=%v median=%v 90th=%v\n", latencyTracker, latencySummary.max, latencySummary.min, latencySummary.median, latencySummary.percentile90)
 	}
 	w.Flush()

--- a/pkg/cmd/audit/io.go
+++ b/pkg/cmd/audit/io.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -277,7 +278,7 @@ func PrintLatencyTrackersStatsAuditEvents(writer io.Writer, events []*auditv1.Ev
 
 			latencyDuration, err := time.ParseDuration(latencyValue)
 			if err != nil {
-				fmt.Println(fmt.Sprintf("Error parsing %q=%v duration, err=%v", latencyTracker, latencyValue, err))
+				fmt.Println(fmt.Sprintf("Error parsing %q=%v duration, for an event with auditID=%v, err=%v", latencyTracker, latencyValue, event.AuditID, err))
 				continue
 			}
 			latencyTrackers[latencyTracker] = append(latencyTrackers[latencyTracker], latencyDuration)
@@ -291,13 +292,13 @@ func PrintLatencyTrackersStatsAuditEvents(writer io.Writer, events []*auditv1.Ev
 	}
 
 	type latencySummary struct {
-		min, max, median, percentile90 time.Duration
+		min, max, median, p90 time.Duration
 	}
 	latencySummaries := map[string]latencySummary{}
 	for latencyTracker, latencies := range latencyTrackers {
-		min, max, median := statsForLatencyTrackers(latencies)
+		min, max, median, p90 := statsForLatencyTrackers(90, latencies)
 		latencySummaries[latencyTracker] = latencySummary{
-			min: min, max: max, median: median,
+			min: min, max: max, median: median, p90: p90,
 		}
 	}
 
@@ -311,35 +312,47 @@ func PrintLatencyTrackersStatsAuditEvents(writer io.Writer, events []*auditv1.Ev
 	fmt.Fprintln(w, "======================================================================")
 	for _, latencyTracker := range sortedLatencyTrackers {
 		latencySummary := latencySummaries[latencyTracker]
-		fmt.Fprintf(w, "%-50s: max=%v min=%v median=%v 90th=%v\n", latencyTracker, latencySummary.max, latencySummary.min, latencySummary.median, latencySummary.percentile90)
+		fmt.Fprintf(w, "%-50s: max=%v min=%v median=%v 90th=%v\n", latencyTracker, latencySummary.max, latencySummary.min, latencySummary.median, latencySummary.p90)
 	}
 	w.Flush()
 }
 
-// TODO: calc 90th
-func statsForLatencyTrackers(latencies []time.Duration) (time.Duration, time.Duration, time.Duration) {
+func statsForLatencyTrackers(percentile float64, latencies []time.Duration) (time.Duration, time.Duration, time.Duration, time.Duration) {
 	if len(latencies) <= 1 {
-		return time.Duration(0), time.Duration(0), time.Duration(0)
+		return time.Duration(0), time.Duration(0), time.Duration(0), time.Duration(0)
 	}
 
-	mean := func(latency1, latency2 time.Duration) time.Duration {
+	isWholeNumberFn := func(num float64) bool {
+		return num == math.Floor(num)
+	}
+	meanFn := func(latency1, latency2 time.Duration) time.Duration {
 		latency1Ns := latency1.Nanoseconds()
 		latency2Ns := latency2.Nanoseconds()
 		meanLatencyNs := (latency1Ns + latency2Ns) / 2
 		return time.Duration(meanLatencyNs)
 	}
-	median := func(latencies []time.Duration) time.Duration {
+	medianFn := func(latencies []time.Duration) time.Duration {
 		var median time.Duration
 		if len(latencies)%2 == 0 {
 			latencies = latencies[len(latencies)/2-1 : len(latencies)/2+1]
-			median = mean(latencies[0], latencies[1])
+			median = meanFn(latencies[0], latencies[1])
 		} else {
 			median = latencies[len(latencies)/2]
 		}
 		return median
 	}
+	percentileFn := func(percentile float64, latencies []time.Duration) time.Duration {
+		indexForPercentile := (percentile / 100.0) * float64(len(latencies))
+		if isWholeNumberFn(indexForPercentile) {
+			return latencies[int(indexForPercentile)]
+		}
+		if indexForPercentile > 1 {
+			return meanFn(latencies[int(indexForPercentile)-1], latencies[int(indexForPercentile)])
+		}
+		return latencies[0]
+	}
 
-	return latencies[0], latencies[len(latencies)-1], median(latencies)
+	return latencies[0], latencies[len(latencies)-1], medianFn(latencies), percentileFn(percentile, latencies)
 }
 
 func GetEvents(auditFilenames ...string) ([]*auditv1.Event, error) {


### PR DESCRIPTION
the new option calculates and displays a summary of statistical metrics (max, min, median, 90th percentile) for the latency trackers (measure latency incurred in components within the apiserver) stored in the audit logs for http requests.

usage:
```
./kubectl-dev_tool audit -f /audit.log -o stats

Summary of the requests latencies (analysed requests: 37392):
======================================================================
apiserver.latency.k8s.io/decode-response-object   : max=241.274µs min=60.191µs median=196.574µs 90th=227.009µs
apiserver.latency.k8s.io/etcd                     : max=1m0.003963671s min=28.052µs median=14.998918564s 90th=59.999428921s
apiserver.latency.k8s.io/mutating-webhook         : max=0s min=0s median=0s 90th=0s
apiserver.latency.k8s.io/response-write           : max=107.110279ms min=151ns median=591ns 90th=1.212µs
apiserver.latency.k8s.io/serialize-response-object: max=19.255044ms min=15.179µs median=2.624864ms 90th=4.179904ms
apiserver.latency.k8s.io/total                    : max=2m35.352837698s min=501.720592ms median=15.002956031s 90th=1m0.00091996s
apiserver.latency.k8s.io/transform-response-object: max=731ns min=40ns median=151ns 90th=330ns
apiserver.latency.k8s.io/validating-webhook       : max=3.077167ms min=67.034µs median=2.198373ms 90th=2.873546ms
```