### PR TITLE
POC:WIP: detect increased requests latency from audit logs.

### DIFF
--- a/pkg/cmd/audit/audit.go
+++ b/pkg/cmd/audit/audit.go
@@ -298,7 +298,7 @@ func (o *AuditOptions) Run() error {
 			}
 		}
 	case o.output == "stats":
-		PrintLatencyTrackersStatsAuditEvents(o.Out, events)
+		AnalyseLatencyTrackersFromAuditEvents(o.Out, events)
 	default:
 		return fmt.Errorf("unsupported output format")
 	}

--- a/pkg/cmd/audit/audit.go
+++ b/pkg/cmd/audit/audit.go
@@ -137,6 +137,7 @@ func (o *AuditOptions) Validate() error {
 		}
 	case o.output == "wide":
 	case o.output == "json":
+	case o.output == "stats":
 	default:
 		return fmt.Errorf("unsupported output format: top=N, wide, json")
 	}
@@ -296,6 +297,8 @@ func (o *AuditOptions) Run() error {
 				return err
 			}
 		}
+	case o.output == "stats":
+		PrintLatencyTrackersStatsAuditEvents(o.Out, events)
 	default:
 		return fmt.Errorf("unsupported output format")
 	}

--- a/pkg/cmd/audit/io.go
+++ b/pkg/cmd/audit/io.go
@@ -300,12 +300,17 @@ func PrintLatencyTrackersStatsAuditEvents(writer io.Writer, events []*auditv1.Ev
 		}
 	}
 
-	//TODO: sort trackers
+	sortedLatencyTrackers := []string{}
+	for latencyTracker, _ := range latencyTrackers {
+		sortedLatencyTrackers = append(sortedLatencyTrackers, latencyTracker)
+	}
+	sort.Strings(sortedLatencyTrackers)
 
 	w := tabwriter.NewWriter(writer, 0, 0, 2, ' ', tabwriter.AlignRight)
 	fmt.Fprintln(w, fmt.Sprintf("Summary of the requests latencies (analysed requests: %d):", len(events)))
 	fmt.Fprintln(w, "======================================================================")
-	for latencyTracker, latencySummary := range latencySummaries {
+	for _, latencyTracker := range sortedLatencyTrackers {
+		latencySummary := latencySummaries[latencyTracker]
 		fmt.Fprintf(w, "%-50s: max=%v min=%v median=%v 90th=%v\n", latencyTracker, latencySummary.max, latencySummary.min, latencySummary.median, latencySummary.percentile90)
 	}
 	w.Flush()

--- a/pkg/cmd/audit/io.go
+++ b/pkg/cmd/audit/io.go
@@ -265,6 +265,78 @@ func PrintTopByVerbAuditEvents(writer io.Writer, numToDisplay int, events []*aud
 	}
 }
 
+func PrintLatencyTrackersStatsAuditEvents(writer io.Writer, events []*auditv1.Event) {
+	latencyTrackers := map[string][]time.Duration{}
+	for _, event := range events {
+		for latencyTracker, latencyValue := range event.Annotations {
+			if !strings.HasPrefix(latencyTracker, "apiserver.latency.k8s.io/") {
+				continue
+			}
+
+			latencyDuration, err := time.ParseDuration(latencyValue)
+			if err != nil {
+				fmt.Println(fmt.Sprintf("Error parsing %q=%v duration, err=%v", latencyTracker, latencyValue, err))
+				continue
+			}
+			latencyTrackers[latencyTracker] = append(latencyTrackers[latencyTracker], latencyDuration)
+		}
+	}
+
+	for latencyTracker, latencies := range latencyTrackers {
+		sort.Slice(latencies, func(i, j int) bool {
+			return latencies[i] < latencies[j]
+		})
+		latencyTrackers[latencyTracker] = latencies
+	}
+
+	type latencySummary struct {
+		min, max, median, percentile90 time.Duration
+	}
+	latencySummaries := map[string]latencySummary{}
+	for latencyTracker, latencies := range latencyTrackers {
+		min, max, median := statsForLatencyTrackers(latencies)
+		latencySummaries[latencyTracker] = latencySummary{
+			min: min, max: max, median: median,
+		}
+	}
+
+	//TODO: sort trackers
+
+	w := tabwriter.NewWriter(writer, 0, 0, 2, ' ', tabwriter.AlignRight)
+	fmt.Fprintln(w, fmt.Sprintf("Summary of the requests latencies (analysed requests: %d):", len(events)))
+	fmt.Fprintln(w, "======================================================================")
+	for latencyTracker, latencySummary := range latencySummaries {
+		fmt.Fprintf(w, "%-50s: max=%v min=%v median=%v 90th=%v\n", latencyTracker, latencySummary.max, latencySummary.min, latencySummary.median, latencySummary.percentile90)
+	}
+	w.Flush()
+}
+
+// TODO: calc 90th
+func statsForLatencyTrackers(latencies []time.Duration) (time.Duration, time.Duration, time.Duration) {
+	if len(latencies) <= 1 {
+		return time.Duration(0), time.Duration(0), time.Duration(0)
+	}
+
+	mean := func(latency1, latency2 time.Duration) time.Duration {
+		latency1Ns := latency1.Nanoseconds()
+		latency2Ns := latency2.Nanoseconds()
+		meanLatencyNs := (latency1Ns + latency2Ns) / 2
+		return time.Duration(meanLatencyNs)
+	}
+	median := func(latencies []time.Duration) time.Duration {
+		var median time.Duration
+		if len(latencies)%2 == 0 {
+			latencies = latencies[len(latencies)/2-1 : len(latencies)/2+1]
+			median = mean(latencies[0], latencies[1])
+		} else {
+			median = latencies[len(latencies)/2]
+		}
+		return median
+	}
+
+	return latencies[0], latencies[len(latencies)-1], median(latencies)
+}
+
 func GetEvents(auditFilenames ...string) ([]*auditv1.Event, error) {
 	ret, readFailures, err := getEventFromManyFiles(auditFilenames...)
 	if readFailures > 0 {

--- a/pkg/cmd/audit/latency_tracker_analyser.go
+++ b/pkg/cmd/audit/latency_tracker_analyser.go
@@ -1,0 +1,60 @@
+package audit
+
+import (
+	"sort"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type AnalysedEventsWithLatencyTrackerSpan struct {
+	Events []*EventWithLatencyTracker
+	Min    time.Duration
+	Max    time.Duration
+	Median time.Duration
+	P90    time.Duration
+
+	FirstEventTimeStamp metav1.MicroTime
+	LastEventTimeStamp  metav1.MicroTime
+}
+
+type latencyTrackerAnalyser struct {
+	iterator       *slidingWindowIteratorForLatencyTracker
+	latencyTracker string
+}
+
+func NewLatencyTrackerAnalyser(iterator *slidingWindowIteratorForLatencyTracker) *latencyTrackerAnalyser {
+	return &latencyTrackerAnalyser{iterator: iterator}
+}
+
+func (l *latencyTrackerAnalyser) RunAnalysis() []*AnalysedEventsWithLatencyTrackerSpan {
+	analysedEvents := []*AnalysedEventsWithLatencyTrackerSpan{}
+
+	for {
+		eventsWithLatenciesSpan, hasMoreData := l.iterator.Next()
+		if !hasMoreData {
+			break
+		}
+		if len(eventsWithLatenciesSpan) <= 1 {
+			continue
+		}
+
+		latencies := EventWithLatencyTrackerToDuration(eventsWithLatenciesSpan)
+
+		sort.Slice(latencies, func(i, j int) bool {
+			return latencies[i] < latencies[j]
+		})
+
+		analysedEvents = append(analysedEvents, &AnalysedEventsWithLatencyTrackerSpan{
+			Events:              eventsWithLatenciesSpan,
+			Min:                 latencies[0],
+			Max:                 latencies[len(latencies)-1],
+			Median:              Median(latencies),
+			P90:                 Percentile(90, latencies),
+			FirstEventTimeStamp: eventsWithLatenciesSpan[0].Event.RequestReceivedTimestamp,
+			LastEventTimeStamp:  eventsWithLatenciesSpan[len(eventsWithLatenciesSpan)-1].Event.RequestReceivedTimestamp,
+		})
+	}
+
+	return analysedEvents
+}

--- a/pkg/cmd/audit/latency_tracker_detector.go
+++ b/pkg/cmd/audit/latency_tracker_detector.go
@@ -1,0 +1,62 @@
+package audit
+
+import (
+	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+func DetectIncreasedLatencyFromAnalysedEventsWithLatencyTrackerSpans(analysedEventsWithLatencyTrackerSpans []*AnalysedEventsWithLatencyTrackerSpan, latencyTracker string) {
+	var spansWithIncreasedLatency []*AnalysedEventsWithLatencyTrackerSpan
+	var currentSpan *AnalysedEventsWithLatencyTrackerSpan
+	increasedLatencyThreshold := 2 * time.Second
+
+	for _, analysedEventsWithLatencyTrackerSpan := range analysedEventsWithLatencyTrackerSpans {
+		if analysedEventsWithLatencyTrackerSpan.Median >= increasedLatencyThreshold {
+			if currentSpan == nil {
+				currentSpan = analysedEventsWithLatencyTrackerSpan
+				continue
+			}
+			if analysedEventsWithLatencyTrackerSpan.FirstEventTimeStamp.Before(&currentSpan.LastEventTimeStamp) || analysedEventsWithLatencyTrackerSpan.FirstEventTimeStamp.Equal(&currentSpan.LastEventTimeStamp) {
+				spansWithIncreasedLatency = append(spansWithIncreasedLatency, analysedEventsWithLatencyTrackerSpan)
+				currentSpan = analysedEventsWithLatencyTrackerSpan
+				continue
+			}
+			printIncreasedLatencyFor(latencyTracker, spansWithIncreasedLatency)
+			currentSpan = analysedEventsWithLatencyTrackerSpan
+			spansWithIncreasedLatency = nil
+		}
+	}
+	printIncreasedLatencyFor(latencyTracker, spansWithIncreasedLatency)
+	printIncreasedLatencyFor(latencyTracker, []*AnalysedEventsWithLatencyTrackerSpan{currentSpan})
+}
+
+func printIncreasedLatencyFor(latencyTracker string, spansWithIncreasedLatency []*AnalysedEventsWithLatencyTrackerSpan) {
+	if len(spansWithIncreasedLatency) == 0 {
+		return
+	}
+
+	var totalEvents int
+	var firstEventTime metav1.MicroTime
+	var lastEventTime metav1.MicroTime
+
+	firstEventTime = spansWithIncreasedLatency[0].FirstEventTimeStamp
+	for _, spanWithIncreasedLatency := range spansWithIncreasedLatency {
+		totalEvents = totalEvents + len(spanWithIncreasedLatency.Events)
+		lastEventTime = spanWithIncreasedLatency.LastEventTimeStamp
+	}
+
+	fmt.Println("")
+	fmt.Println(fmt.Sprintf("increased latency for tracker: %s detected, from: %v, to: %v, totalEvents: %v\n", latencyTracker, firstEventTime, lastEventTime, totalEvents))
+	for _, spanWithIncreasedLatency := range spansWithIncreasedLatency {
+		fmt.Println(fmt.Sprintf("tracker=%v, min=%v max=%v median=%v 90th=%v events=%v [%v - %v]\n",
+			latencyTracker,
+			spanWithIncreasedLatency.Min,
+			spanWithIncreasedLatency.Max,
+			spanWithIncreasedLatency.Median,
+			spanWithIncreasedLatency.P90,
+			len(spanWithIncreasedLatency.Events),
+			spanWithIncreasedLatency.FirstEventTimeStamp,
+			spanWithIncreasedLatency.LastEventTimeStamp))
+	}
+}

--- a/pkg/cmd/audit/latency_tracker_helpers.go
+++ b/pkg/cmd/audit/latency_tracker_helpers.go
@@ -1,0 +1,86 @@
+package audit
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+)
+
+// TODO: should not be part of this file/pkg
+type EventWithLatencyTracker struct {
+	Event   *auditv1.Event
+	Latency time.Duration
+}
+
+// ToSortedEventWithLatencyTracker aggregates audit events by "apiserver.latency.k8s.io" annotation and stores them in a sorted array (by RequestReceivedTimestamp).
+func ToSortedEventWithLatencyTracker(events []*auditv1.Event) map[string][]*EventWithLatencyTracker {
+	eventsWithLatencyTracker := map[string][]*EventWithLatencyTracker{}
+	for _, event := range events {
+		for latencyTracker, latencyValue := range event.Annotations {
+			if !strings.HasPrefix(latencyTracker, "apiserver.latency.k8s.io/") {
+				continue
+			}
+
+			latencyDuration, err := time.ParseDuration(latencyValue)
+			if err != nil {
+				fmt.Println(fmt.Sprintf("Error parsing %q=%v duration, err=%v", latencyTracker, latencyValue, err))
+				continue
+			}
+			eventsWithLatencyTracker[latencyTracker] = append(eventsWithLatencyTracker[latencyTracker], &EventWithLatencyTracker{Event: event, Latency: latencyDuration})
+		}
+	}
+
+	for latencyTracker, eventsWithLatencies := range eventsWithLatencyTracker {
+		sort.Slice(eventsWithLatencies, func(i, j int) bool {
+			return eventsWithLatencies[i].Event.RequestReceivedTimestamp.Before(&eventsWithLatencies[j].Event.RequestReceivedTimestamp)
+		})
+		eventsWithLatencyTracker[latencyTracker] = eventsWithLatencies
+	}
+
+	return eventsWithLatencyTracker
+}
+
+func EventWithLatencyTrackerToDuration(eventsWithLatencyTracker []*EventWithLatencyTracker) []time.Duration {
+	latencies := make([]time.Duration, len(eventsWithLatencyTracker))
+	for i, eventWithLatencyTracker := range eventsWithLatencyTracker {
+		latencies[i] = eventWithLatencyTracker.Latency
+	}
+	return latencies
+}
+
+func IsWholeNumber(num float64) bool {
+	return num == math.Floor(num)
+}
+
+func Mean(latency1, latency2 time.Duration) time.Duration {
+	latency1Ns := latency1.Nanoseconds()
+	latency2Ns := latency2.Nanoseconds()
+	meanLatencyNs := (latency1Ns + latency2Ns) / 2
+	return time.Duration(meanLatencyNs)
+}
+
+func Median(latencies []time.Duration) time.Duration {
+	var median time.Duration
+	if len(latencies)%2 == 0 {
+		latencies = latencies[len(latencies)/2-1 : len(latencies)/2+1]
+		median = Mean(latencies[0], latencies[1])
+	} else {
+		median = latencies[len(latencies)/2]
+	}
+	return median
+}
+
+func Percentile(percentile float64, latencies []time.Duration) time.Duration {
+	indexForPercentile := (percentile / 100.0) * float64(len(latencies))
+	if IsWholeNumber(indexForPercentile) {
+		return latencies[int(indexForPercentile)]
+	}
+	if indexForPercentile > 1 {
+		return Mean(latencies[int(indexForPercentile)-1], latencies[int(indexForPercentile)])
+	}
+	return 0
+}

--- a/pkg/cmd/audit/sliding_window_iterator.go
+++ b/pkg/cmd/audit/sliding_window_iterator.go
@@ -1,0 +1,67 @@
+package audit
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TODO: should not be part of this file/pkg
+type latencyTrackerTuple struct {
+	latency   time.Duration
+	timestamp metav1.MicroTime
+}
+
+type slidingWindowIterator struct {
+	data           []latencyTrackerTuple
+	windowDuration time.Duration
+	stepDuration   time.Duration
+	currentIndex   int
+	stepIndex      int
+	windowStart    time.Time
+	windowEnd      time.Time
+}
+
+func NewSlidingWindowIterator(data []latencyTrackerTuple, windowDuration, stepDuration time.Duration) *slidingWindowIterator {
+	if len(data) == 0 {
+		return &slidingWindowIterator{}
+	}
+
+	return &slidingWindowIterator{
+		data:           data,
+		windowDuration: windowDuration,
+		stepDuration:   stepDuration,
+		currentIndex:   0,
+		stepIndex:      0,
+		windowStart:    data[0].timestamp.Time,
+		windowEnd:      data[0].timestamp.Time.Add(windowDuration),
+	}
+}
+
+func (it *slidingWindowIterator) Next() []latencyTrackerTuple {
+	if it.currentIndex >= len(it.data) {
+		return nil
+	}
+
+	var windowData []latencyTrackerTuple
+	for i := it.currentIndex; i < len(it.data); i++ {
+		entry := it.data[i]
+		if entry.timestamp.Time.After(it.windowEnd) {
+			break
+		}
+
+		if entry.timestamp.Time.After(it.windowStart) || entry.timestamp.Time.Equal(it.windowStart) {
+			windowData = append(windowData, entry)
+		}
+
+		if !entry.timestamp.Time.After(it.windowStart.Add(it.stepDuration)) {
+			it.stepIndex = i
+		}
+	}
+
+	it.windowStart = it.windowStart.Add(it.stepDuration)
+	it.windowEnd = it.windowStart.Add(it.windowDuration)
+	it.currentIndex = it.stepIndex
+
+	return windowData
+}


### PR DESCRIPTION
```
❯ ./kubectl-dev_tool audit -f audit.log --stage=ResponseComplete -o stats

increased latency for tracker: apiserver.latency.k8s.io/etcd detected, from: 2024-07-23 01:26:15.374266 +0200 CEST, to: 2024-07-23 01:28:08.084897 +0200 CEST, totalEvents: 4707

tracker=apiserver.latency.k8s.io/etcd, min=5.999151357s max=1m0.003963671s median=14.999281279s 90th=59.999766772s events=1432 [2024-07-23 01:26:15.374266 +0200 CEST - 2024-07-23 01:27:11.864862 +0200 CEST]

tracker=apiserver.latency.k8s.io/etcd, min=5.999662741s max=1m0.003140176s median=14.999079115s 90th=59.99946593s events=1368 [2024-07-23 01:26:41.953009 +0200 CEST - 2024-07-23 01:27:41.865684 +0200 CEST]

tracker=apiserver.latency.k8s.io/etcd, min=5.999838559s max=1m0.000907557s median=14.998924886s 90th=56.156543455s events=1304 [2024-07-23 01:27:11.952965 +0200 CEST - 2024-07-23 01:28:08.084897 +0200 CEST]

tracker=apiserver.latency.k8s.io/etcd, min=6.000189594s max=1m0.000907557s median=14.998449838s 90th=21.002733985s events=603 [2024-07-23 01:27:41.95378 +0200 CEST - 2024-07-23 01:28:08.084897 +0200 CEST]


increased latency for tracker: apiserver.latency.k8s.io/etcd detected, from: 2024-07-23 01:32:30.189283 +0200 CEST, to: 2024-07-23 01:34:18.424754 +0200 CEST, totalEvents: 3362

tracker=apiserver.latency.k8s.io/etcd, min=5.999939831s max=1m0.000961944s median=15.000243142s 90th=59.99997495s events=758 [2024-07-23 01:32:30.189283 +0200 CEST - 2024-07-23 01:33:11.864284 +0200 CEST]

tracker=apiserver.latency.k8s.io/etcd, min=5.999750971s max=1m0.000961944s median=14.999699291s 90th=59.999637897s events=966 [2024-07-23 01:32:41.952189 +0200 CEST - 2024-07-23 01:33:41.867796 +0200 CEST]

tracker=apiserver.latency.k8s.io/etcd, min=4.158830543s max=1m0.000746847s median=14.99908652s 90th=59.482115474s events=975 [2024-07-23 01:33:11.953796 +0200 CEST - 2024-07-23 01:34:11.867509 +0200 CEST]

tracker=apiserver.latency.k8s.io/etcd, min=4.158830543s max=1m0.000686771s median=14.99870116s 90th=15.023435927s events=564 [2024-07-23 01:33:41.952985 +0200 CEST - 2024-07-23 01:34:18.424754 +0200 CEST]

tracker=apiserver.latency.k8s.io/etcd, min=5.999903894s max=59.999955725s median=14.999043598s 90th=15.000539502s events=99 [2024-07-23 01:34:11.952101 +0200 CEST - 2024-07-23 01:34:18.424754 +0200 CEST]


increased latency for tracker: apiserver.latency.k8s.io/etcd detected, from: 2024-07-23 01:34:11.952101 +0200 CEST, to: 2024-07-23 01:34:18.424754 +0200 CEST, totalEvents: 99

tracker=apiserver.latency.k8s.io/etcd, min=5.999903894s max=59.999955725s median=14.999043598s 90th=15.000539502s events=99 [2024-07-23 01:34:11.952101 +0200 CEST - 2024-07-23 01:34:18.424754 +0200 CEST]
````