### PR TITLE
generate gnuplot data/command file for latency distribution 

### DIFF
--- a/pkg/cmd/audit/audit.go
+++ b/pkg/cmd/audit/audit.go
@@ -222,21 +222,31 @@ func (o *AuditOptions) Run() error {
 		filters = append(filters, &FilterByAfter{After: t})
 	}
 	if len(o.resources) > 0 {
-		resources := map[schema.GroupResource]bool{}
-		for _, resource := range o.resources {
-			parts := strings.Split(resource, ".")
-			gr := schema.GroupResource{}
-			gr.Resource = parts[0]
-			if len(parts) >= 2 {
-				gr.Group = strings.Join(parts[1:], ".")
+		switch {
+		case len(o.resources) == 1 && o.resources[0] == "*":
+			filters = append(filters, FilterByAnyResources{})
+		default:
+			resources := map[schema.GroupResource]bool{}
+			for _, resource := range o.resources {
+				parts := strings.Split(resource, ".")
+				gr := schema.GroupResource{}
+				gr.Resource = parts[0]
+				if len(parts) >= 2 {
+					gr.Group = strings.Join(parts[1:], ".")
+				}
+				resources[gr] = true
 			}
-			resources[gr] = true
-		}
 
-		filters = append(filters, &FilterByResources{Resources: resources})
+			filters = append(filters, &FilterByResources{Resources: resources})
+		}
 	}
 	if len(o.subresources) > 0 {
-		filters = append(filters, &FilterBySubresources{Subresources: sets.NewString(o.subresources...)})
+		switch {
+		case len(o.subresources) == 1 && o.subresources[0] == "-*":
+			filters = append(filters, FilterByNoSubresource{})
+		default:
+			filters = append(filters, &FilterBySubresources{Subresources: sets.NewString(o.subresources...)})
+		}
 	}
 	if len(o.users) > 0 {
 		filters = append(filters, &FilterByUser{Users: sets.NewString(o.users...)})

--- a/pkg/cmd/audit/audit.go
+++ b/pkg/cmd/audit/audit.go
@@ -53,6 +53,7 @@ type AuditOptions struct {
 	failedOnly        bool
 	httpStatusCodes   []int32
 	output            string
+	to                string
 	topBy             string
 	beforeString      string
 	afterString       string
@@ -99,6 +100,7 @@ func NewCmdAudit(parentName string, streams genericclioptions.IOStreams) *cobra.
 
 	cmd.Flags().StringSliceVarP(&o.filenames, "filename", "f", o.filenames, "Search for audit logs that contains specified URI")
 	cmd.Flags().StringVarP(&o.output, "output", "o", o.output, "Choose your output format")
+	cmd.Flags().StringVar(&o.to, "to", o.to, "Choose the directory where output files will be created, if not provided output files will be written to the tmp folder")
 	cmd.Flags().StringSliceVar(&o.uids, "uid", o.uids, "Only match specific UIDs")
 	cmd.Flags().StringSliceVar(&o.verbs, "verb", o.verbs, "Filter result of search to only contain the specified verb (eg. 'update', 'get', etc..)")
 	cmd.Flags().StringSliceVar(&o.resources, "resource", o.resources, "Filter result of search to only contain the specified resource.)")
@@ -140,6 +142,7 @@ func (o *AuditOptions) Validate() error {
 	case o.output == "wide":
 	case o.output == "json":
 	case o.output == "stats":
+	case o.output == "latency-dist":
 	default:
 		return fmt.Errorf("unsupported output format: top=N, wide, json")
 	}
@@ -314,6 +317,11 @@ func (o *AuditOptions) Run() error {
 		}
 	case o.output == "stats":
 		PrintLatencyTrackersStatsAuditEvents(o.Out, events)
+	case o.output == "latency-dist":
+		writer := plotWriter{o.to}
+		if err := writer.Write(events); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("unsupported output format")
 	}

--- a/pkg/cmd/audit/audit_filter.go
+++ b/pkg/cmd/audit/audit_filter.go
@@ -79,6 +79,15 @@ func (f *FilterByNamespaces) Matches(event *auditv1.Event) bool {
 
 }
 
+type FilterByNoSubresource struct{}
+
+func (f FilterByNoSubresource) Matches(event *auditv1.Event) bool {
+	if event.ObjectRef != nil && len(event.ObjectRef.Subresource) == 0 {
+		return true
+	}
+	return false
+}
+
 type FilterBySubresources struct {
 	Subresources sets.String
 }
@@ -144,6 +153,16 @@ type FilterByVerbs struct {
 
 func (f *FilterByVerbs) Matches(event *auditv1.Event) bool {
 	return util.AcceptString(f.Verbs, event.Verb)
+}
+
+type FilterByAnyResources struct{}
+
+func (f FilterByAnyResources) Matches(event *auditv1.Event) bool {
+	if event.ObjectRef != nil && len(event.ObjectRef.Resource) > 0 {
+		// the request is a resource scoped
+		return true
+	}
+	return false
 }
 
 type FilterByResources struct {

--- a/pkg/cmd/audit/io.go
+++ b/pkg/cmd/audit/io.go
@@ -367,6 +367,9 @@ func GetEvents(auditFilenames ...string) ([]*auditv1.Event, error) {
 	if readFailures > 0 {
 		fmt.Fprintf(os.Stderr, "had %d line read failures\n", readFailures)
 	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+	}
 
 	// sort events by time
 	sort.Slice(ret, func(i, j int) bool {
@@ -434,8 +437,7 @@ func getEventsFromFile(auditFilename string) ([]*auditv1.Event, int, error) {
 		return nil, 0, err
 	}
 
-	scanner := bufio.NewScanner(file)
-	return getEventsFromScanner(auditFilename, scanner)
+	return getEventsFromReader(auditFilename, file)
 }
 
 func getEventsFromZipFile(auditFilename string) ([]*auditv1.Event, int, error) {
@@ -459,13 +461,18 @@ func getEventsFromZipFile(auditFilename string) ([]*auditv1.Event, int, error) {
 	if err != nil {
 		return nil, 0, err
 	}
-	scanner := bufio.NewScanner(zw)
-	return getEventsFromScanner(auditFilename, scanner)
+	return getEventsFromReader(auditFilename, zw)
 }
 
-func getEventsFromScanner(auditFilename string, scanner *bufio.Scanner) ([]*auditv1.Event, int, error) {
+func getEventsFromReader(auditFilename string, reader io.Reader) ([]*auditv1.Event, int, error) {
 	ret := []*auditv1.Event{}
 	failures := 0
+
+	scanner := bufio.NewScanner(reader)
+	// some audit entry may be really long due to response object being
+	// included, use an initil buffer of 4K and let it grow up to 128K
+	buf := make([]byte, 4*1024)
+	scanner.Buffer(buf, 2*bufio.MaxScanTokenSize)
 
 	// each line in audit file use following format: `hostname {JSON}`, we are not interested in hostname,
 	// so lets parse out the events.
@@ -498,6 +505,13 @@ func getEventsFromScanner(auditFilename string, scanner *bufio.Scanner) ([]*audi
 		// Add to index
 		ret = append(ret, eventObj)
 	}
+	// any error other than io.EOF means that we are dropping unknown
+	// number of events, this should be an error condition
+	if err := scanner.Err(); err != nil {
+		failures++
+		return ret, failures, fmt.Errorf("unexpected error processing file: %q, line number: %d, err: %w", auditFilename, line+1, err)
+	}
+
 	return ret, failures, nil
 }
 func getEventsFromDirectory(auditFilename string) ([]*auditv1.Event, int, error) {

--- a/pkg/cmd/audit/plot.go
+++ b/pkg/cmd/audit/plot.go
@@ -1,0 +1,71 @@
+package audit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+)
+
+type plotWriter struct {
+	to string
+}
+
+func (w plotWriter) Write(events []*auditv1.Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	to := w.to
+	if len(to) == 0 {
+		tmpDir, err := os.MkdirTemp("", "gnuplot-")
+		if err != nil {
+			return fmt.Errorf("error creating temporary directory: %w", err)
+		}
+		to = tmpDir
+	}
+
+	dat, err := os.OpenFile(filepath.Join(to, "output.dat"), os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open data file to write: %w", err)
+	}
+
+	const dateFmt = "2006-01-02 15:04:05.000"
+	var yMax int64
+	func() {
+		defer dat.Close()
+		for _, event := range events {
+			duration := event.StageTimestamp.Time.Sub(event.RequestReceivedTimestamp.Time).Milliseconds()
+			if duration <= 0 {
+				continue
+			}
+			if duration > yMax {
+				yMax = duration
+			}
+			from := event.RequestReceivedTimestamp.Time.Format(dateFmt)
+			fmt.Fprintf(dat, "%s,%d\n", from, duration)
+		}
+	}()
+
+	gp, err := os.OpenFile(filepath.Join(to, "output.gp"), os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open command file to write: %w", err)
+	}
+	defer gp.Close()
+
+	fmt.Fprintf(gp, "set title \"latency distribution over time\" font \",16\"\n")
+	fmt.Fprintf(gp, "set xlabel \"time\"\n")
+	fmt.Fprintf(gp, "set ylabel \"latency im milliseconds\"\n")
+	fmt.Fprintf(gp, "set grid\n")
+	fmt.Fprintf(gp, "set datafile separator \",\"\n")
+	fmt.Fprintf(gp, "set xdata time\n")
+	fmt.Fprintf(gp, "set format x \"%%Y-%%m-%%d\\n%%H:%%M:%%S\"\n")
+	fmt.Fprintf(gp, "set timefmt \"%%Y-%%m-%%d %%H:%%M:%%S\"\n")
+
+	xMin := events[0].RequestReceivedTimestamp.Time.Format(dateFmt)
+	xMax := events[len(events)-1].RequestReceivedTimestamp.Time.Format(dateFmt)
+	fmt.Fprintf(gp, "set xrange [\"%s\":\"%s\"]\n", xMin, xMax)
+	fmt.Fprintf(gp, "set yrange [0:%d]\n", yMax)
+	return nil
+}


### PR DESCRIPTION
gnuplot latency distribution using the audit events:

```
$ gnuplot

gnuplot> load "output.gp"
gnuplot> plot "output.dat" using 1:2
```
<img width="1918" height="1007" alt="image" src="https://github.com/user-attachments/assets/d6122959-ae39-401e-bf29-9994de9fa393" />

example command to generate latency distribution:
```
./kubectl-dev_tool audit -f kube-apiserver-audit.log --verb=get --resource="*" --subresource="-*" --stage=ResponseComplete --output=latency-dist --to=~/tmp
```
